### PR TITLE
15 Commande piloter

### DIFF
--- a/commands/drive.py
+++ b/commands/drive.py
@@ -1,0 +1,37 @@
+import wpilib
+from commands2 import CommandBase
+from wpimath.filter import LinearFilter
+import properties
+from subsystems.drivetrain import DriveTrain
+
+
+def interpolate(value: float):
+    curve = properties.values.drive_interpolation_curve
+    deadzoneX = properties.values.drive_deadzone_x
+    deadzoneY = properties.values.drive_deadzone_y
+
+    if value >= deadzoneX:
+        return deadzoneY + (1 - deadzoneY) * (curve * value**3 + (1 - curve) * value)
+    elif value <= -deadzoneX:
+       return -deadzoneY + (1 - deadzoneY) * (curve * value**3 + (1 - curve) * value)
+    else:
+        return 0.0  # interpolate(deadzoneX) / deadzoneX * value;
+
+
+class Drive(CommandBase):
+    def __init__(self, drivetrain: DriveTrain, stick: wpilib.Joystick):
+        super().__init__()
+        self.stick = stick
+        self.drivetrain = drivetrain
+        self.addRequirements(drivetrain)
+        self.setName("Drive")
+
+    def initialize(self) -> None:
+        self.forward_filter = LinearFilter.movingAverage(int(properties.values.drive_smoothing_window))
+        self.turn_filter = LinearFilter.movingAverage(int(properties.values.drive_smoothing_window))
+
+    def execute(self):
+        forward = interpolate(self.stick.getY()) * -1
+        turn = interpolate(self.stick.getX()) * -1
+
+        self.drivetrain.arcadeDrive(self.forward_filter.calculate(forward), self.turn_filter.calculate(turn))

--- a/properties.py
+++ b/properties.py
@@ -10,8 +10,10 @@ class _Properties:
     - ntproperty strings are the same as their variables
     """
 
-    # Example: intake_speed_slow = ntproperty("/Properties/intake_speed_slow", 300, writeDefault=False, persistent=persistent)
-    pass
+    drive_smoothing_window = ntproperty("/Properties/drive_smoothing_window", 1, writeDefault=False, persistent=persistent)
+    drive_interpolation_curve = ntproperty("/Properties/drive_interpolation_curve", 0.6, writeDefault=False, persistent=persistent)
+    drive_deadzone_x = ntproperty("/Properties/drive_deadzone_x", 0.05, writeDefault=False, persistent=persistent)
+    drive_deadzone_y = ntproperty("/Properties/drive_deadzone_y", 0.05, writeDefault=False, persistent=persistent)
 
 
 values = _Properties()

--- a/robot.py
+++ b/robot.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
-
 import commands2
 import wpilib
 
 from subsystems.drivetrain import DriveTrain
 
+from commands.drive import Drive
+
 
 class Robot(commands2.TimedCommandRobot):
     def robotInit(self):
+        wpilib.LiveWindow.enableAllTelemetry()
         self.drivetrain = DriveTrain()
+        self.stick = wpilib.Joystick(0)
+        self.drivetrain.setDefaultCommand(Drive(self.drivetrain, self.stick))
 
-    def robotPeriodic(self) -> None:
-        pass
 
 if __name__ == "__main__":
     wpilib.run(Robot)


### PR DESCRIPTION
Description
-----------
La commande pour piloter avec le joystick pour une base en tank.
Closes #15. 

Liste de vérification
---------------------
<!-- Entre les [ ], remplace l'espace par un x lorsque c'est fait. -->
- Writing conventions :
    - [x] English language
    - [x] File names use lowercase without spaces
    - [x] Class names use PascalCase
    - [x] Function and variable names use snake_case
    - [x] Function and command names start with an action verb (get, set, move, start, stop...)
    - [x] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
    - [x] Properties respect the naming convention
    - [x] ntproperty strings are the same as their variables
- [x] J'ai exécuté tout mon code en simulation.
