### PR TITLE
DriveTrain a été changé pour Drivetrain

### DIFF
--- a/commands/drive.py
+++ b/commands/drive.py
@@ -2,7 +2,7 @@ import wpilib
 from commands2 import CommandBase
 from wpimath.filter import LinearFilter
 import properties
-from subsystems.drivetrain import DriveTrain
+from subsystems.drivetrain import Drivetrain
 
 
 def interpolate(value: float):
@@ -19,7 +19,7 @@ def interpolate(value: float):
 
 
 class Drive(CommandBase):
-    def __init__(self, drivetrain: DriveTrain, stick: wpilib.Joystick):
+    def __init__(self, drivetrain: Drivetrain, stick: wpilib.Joystick):
         super().__init__()
         self.stick = stick
         self.drivetrain = drivetrain

--- a/robot.py
+++ b/robot.py
@@ -2,7 +2,7 @@
 import commands2
 import wpilib
 
-from subsystems.drivetrain import DriveTrain
+from subsystems.drivetrain import Drivetrain
 
 from commands.drive import Drive
 
@@ -10,7 +10,7 @@ from commands.drive import Drive
 class Robot(commands2.TimedCommandRobot):
     def robotInit(self):
         wpilib.LiveWindow.enableAllTelemetry()
-        self.drivetrain = DriveTrain()
+        self.drivetrain = Drivetrain()
         self.stick = wpilib.Joystick(0)
         self.drivetrain.setDefaultCommand(Drive(self.drivetrain, self.stick))
 

--- a/subsystems/drivetrain.py
+++ b/subsystems/drivetrain.py
@@ -14,8 +14,7 @@ from utils.safesubsystembase import SafeSubsystemBase
 from utils.sparkmaxsim import SparkMaxSim
 import ports
 
-
-class DriveTrain(SafeSubsystemBase):
+class Drivetrain(SafeSubsystemBase):
     def __init__(self) -> None:
         super().__init__()
         # Motors


### PR DESCRIPTION
Description
DriveTrain a été changé pour Drivetrain
Closes #22. 

Liste de vérification
---------------------
<!-- Entre les [ ], remplace l'espace par un x lorsque c'est fait. -->
- Writing conventions :
    - [x] English language
    - [x] File names use lowercase without spaces
    - [x] Class names use PascalCase
    - [x] Function and variable names use snake_case
    - [x] Function and command names start with an action verb (get, set, move, start, stop...)
    - [x] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
    - [x] Properties respect the naming convention
    - [x] ntproperty strings are the same as their variables
- [x] J'ai exécuté tout mon code en simulation.
