### PR TITLE
Added second adis gyro to gyro.py

### DIFF
--- a/gyro.py
+++ b/gyro.py
@@ -73,6 +73,7 @@ class ADIS16448(Gyro):
     def reset(self):
         self.gyro.reset()
 
+
 class ADIS16470(Gyro):
     def __init__(self):
         self.gyro = wpilib.ADIS16470_IMU()
@@ -95,6 +96,8 @@ class ADIS16470(Gyro):
 
     def reset(self):
         self.gyro.reset()
+
+
 class ADXRS(Gyro):
     def __init__(self):
         self.gyro = wpilib.ADXRS450_Gyro()

--- a/gyro.py
+++ b/gyro.py
@@ -51,7 +51,7 @@ class NavX(Gyro):
         self.gyro.reset()
 
 
-class ADIS(Gyro):
+class ADIS16448(Gyro):
     def __init__(self):
         self.gyro = wpilib.ADIS16448_IMU()
         gyro_sim_device = SimDeviceSim("Gyro:ADIS16448[4]")
@@ -73,7 +73,28 @@ class ADIS(Gyro):
     def reset(self):
         self.gyro.reset()
 
+class ADIS16470(Gyro):
+    def __init__(self):
+        self.gyro = wpilib.ADIS16470_IMU()
+        gyro_sim_device = SimDeviceSim("Gyro:ADIS16470[0]")
+        self._gyro_sim_angle = gyro_sim_device.getDouble("gyro_angle_z")
+        self._gyro_sim_pitch = gyro_sim_device.getDouble("gyro_angle_y")
+        self.setSimAngle(40)
 
+    def getAngle(self):
+        return -math.remainder(self.gyro.getAngle(), 360.0)
+
+    def getPitch(self):
+        return math.remainder(self.gyro.getGyroAngleY(), 360.0)
+
+    def setSimAngle(self, angle: float):
+        self._gyro_sim_angle.set(angle)
+
+    def setSimPitch(self, pitch: float):
+        self._gyro_sim_pitch.set(pitch)
+
+    def reset(self):
+        self.gyro.reset()
 class ADXRS(Gyro):
     def __init__(self):
         self.gyro = wpilib.ADXRS450_Gyro()

--- a/gyro.py
+++ b/gyro.py
@@ -1,9 +1,9 @@
 import math
-import navx
-import wpilib
-import hal
 from abc import ABC, abstractmethod
 
+import hal
+import navx
+import wpilib
 from wpilib.simulation import SimDeviceSim
 from wpimath.geometry import Rotation2d
 
@@ -80,7 +80,6 @@ class ADIS16470(Gyro):
         gyro_sim_device = SimDeviceSim("Gyro:ADIS16470[0]")
         self._gyro_sim_angle = gyro_sim_device.getDouble("gyro_angle_z")
         self._gyro_sim_pitch = gyro_sim_device.getDouble("gyro_angle_y")
-        self.setSimAngle(40)
 
     def getAngle(self):
         return -math.remainder(self.gyro.getAngle(), 360.0)

--- a/subsystems/drivetrain.py
+++ b/subsystems/drivetrain.py
@@ -18,7 +18,7 @@ from utils.safesubsystem import SafeSubsystem
 from utils.sparkmaxsim import SparkMaxSim
 import ports
 
-select_gyro: Literal["navx", "adis16448", "adis16470" "adxrs", "empty"] = "adis16470"
+select_gyro: Literal["navx", "adis16448", "adis16470", "adxrs", "empty"] = "adis16470"
 
 
 class Drivetrain(SafeSubsystem):
@@ -58,7 +58,7 @@ class Drivetrain(SafeSubsystem):
             "empty": Empty,
         }[select_gyro]()
         self._odometry = DifferentialDriveOdometry(self._gyro.getRotation2d(), 0, 0, initialPose=Pose2d(0, 0, 0))
-        
+
         self._field = wpilib.Field2d()
         wpilib.SmartDashboard.putData("Field", self._field)
         self._left_encoder_offset = 0

--- a/subsystems/drivetrain.py
+++ b/subsystems/drivetrain.py
@@ -12,13 +12,13 @@ from wpimath.kinematics import DifferentialDriveOdometry
 from wpimath.system import LinearSystemId
 from wpimath.system.plant import DCMotor
 
-from gyro import NavX, ADIS, ADXRS, Empty
+from gyro import NavX, ADIS16448, ADIS16470, ADXRS, Empty
 from utils.sparkmaxutils import configure_follower, configure_leader
 from utils.safesubsystem import SafeSubsystem
 from utils.sparkmaxsim import SparkMaxSim
 import ports
 
-select_gyro: Literal["navx", "adis", "adxrs", "empty"] = "navx"
+select_gyro: Literal["navx", "adis16448", "adis16470" "adxrs", "empty"] = "adis16470"
 
 
 class Drivetrain(SafeSubsystem):
@@ -52,7 +52,8 @@ class Drivetrain(SafeSubsystem):
 
         self._gyro = {
             "navx": NavX,
-            "adis": ADIS,
+            "adis16448": ADIS16448,
+            "adis16470": ADIS16470,
             "adxrs": ADXRS,
             "empty": Empty,
         }[select_gyro]()

--- a/subsystems/drivetrain.py
+++ b/subsystems/drivetrain.py
@@ -13,8 +13,8 @@ from wpimath.kinematics import DifferentialDriveKinematics
 from wpimath.system import LinearSystemId
 from wpimath.system.plant import DCMotor
 
-from gyro import NavX, ADIS16448, ADIS16470, ADXRS, Empty
 import ports
+from gyro import NavX, ADIS16448, ADIS16470, ADXRS, Empty
 from utils.safesubsystem import SafeSubsystem
 from utils.sparkmaxsim import SparkMaxSim
 from utils.sparkmaxutils import configure_follower, configure_leader


### PR DESCRIPTION
Description
-----------
Ajout du support du gyro ADIS16470 dans gyro.py
Closes #42. 

Liste de vérification
---------------------
<!-- Entre les [ ], remplace l'espace par un x lorsque c'est fait. -->
- Writing conventions :
    - [x] English language
    - [x] File names use lowercase without spaces
    - [x] Class names use PascalCase
    - [x] Functions use camelCase
    - [x] Variable names use snake_case
    - [x] Function and command names start with an action verb (get, set, move, start, stop...)
    - [x] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
    - [x] Properties respect the naming convention
    - [x] ntproperty key strings are the same as their variables
- Command and subsytem safety :
    - [x] Commands and subsystems inherit from SafeCommand and SafeSubsystem
    - [x] No commands or subsytems have a `setName()` method, unless necessary
    - [x] Commands have a `addRequirements()` method that includes all the subsystems they use
- [x] J'ai exécuté tout mon code en simulation.
