### PR TITLE
Fix property conventions + rename to CommonProperties

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,6 @@ Liste de vérification
     - [ ] Function and command names start with an action verb (get, set, move, start, stop...)
     - [ ] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
     - [ ] Properties respect the naming convention
-    - [ ] ntproperty key strings are the same as their variables
 - Command and subsytem safety :
     - [ ] Commands and subsystems inherit from SafeCommand and SafeSubsystem
     - [ ] No commands or subsytems have a `setName()` method, unless necessary

--- a/properties.py
+++ b/properties.py
@@ -1,28 +1,13 @@
-from ntcore import NetworkTableInstance
-from ntcore.util import ntproperty
-
-persistent = True
+from utils.property import autoproperty
 
 
-class _Properties:
+class _CommonProperties:
     """
-    - Respect the naming convention : "subsystem/command" _ "variable type" _ "precision"
-    - ntproperty strings are the same as their variables
+    Respect the naming convention : "subsystem/command" _ "variable type" _ "precision"
+
+    Example:
+        my_variable_name = autoproperty(0.5)  # Default value is 0.5
     """
 
 
-values = _Properties()
-
-
-def check_property_names():
-    import inspect
-    import re
-
-    lines = inspect.getsource(_Properties).splitlines()
-    pattern = re.compile(r'^\s{4}(\w+) = ntproperty\("\/Properties\/(\w+)", [^,]+, writeDefault=False, persistent=persistent\)')
-
-    for line in lines[1:]:
-        if " = ntproperty(" in line:
-            match = pattern.match(line)
-            assert match, "The following property does not respect team conventions : " + line
-            assert match.group(1) == match.group(2), f"Key and name of following property are not equal : {match.group(1)} != {match.group(2)}"
+common = _CommonProperties()


### PR DESCRIPTION
Description
-----------
<!--- Fais un résumé de ce que tu as ajouté. -->
Fixes property conventions and renames Properties to CommonProperties, since most properties will now live in the class that uses them.

Liste de vérification
---------------------
<!-- Entre les [ ], remplace l'espace par un x lorsque c'est fait. -->
- Writing conventions :
    - [ ] English language
    - [ ] File names use lowercase without spaces
    - [ ] Class names use PascalCase
    - [ ] Functions use camelCase
    - [ ] Variable names use snake_case
    - [ ] Function and command names start with an action verb (get, set, move, start, stop...)
    - [ ] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
    - [ ] Properties respect the naming convention
    - [ ] ntproperty key strings are the same as their variables
- Command and subsytem safety :
    - [ ] Commands and subsystems inherit from SafeCommand and SafeSubsystem
    - [ ] No commands or subsytems have a `setName()` method, unless necessary
    - [ ] Commands have a `addRequirements()` method that includes all the subsystems they use
- [ ] J'ai exécuté tout mon code en simulation.
