### PR TITLE
51 remplacer les smartdashboard putnumber par initsendable

### DIFF
--- a/subsystems/drivetrain.py
+++ b/subsystems/drivetrain.py
@@ -2,6 +2,8 @@ from typing import Literal
 
 import rev
 import wpilib
+import wpilib.drive
+import wpiutil
 from photonvision import PhotonCamera, SimVisionSystem, SimVisionTarget
 from robotpy_apriltag import AprilTagField, loadAprilTagLayoutField
 from wpilib import RobotBase, RobotController
@@ -155,3 +157,8 @@ class Drivetrain(SafeSubsystem):
         wpilib.SmartDashboard.putNumber("Right Encoder Position", self.getRightEncoderPosition())
         wpilib.SmartDashboard.putNumber("Left Motor", self._motor_left.get())
         wpilib.SmartDashboard.putNumber("Right Motor", self._motor_right.get())
+    def initSendable(self, builder: wpiutil.SendableBuilder) -> None:
+        super().initSendable(builder)
+        builder.addDoubleProperty("Left motor", self._motor_left.get, None)
+        builder.addDoubleProperty("Right Motor", self._motor_right.get, None)
+

--- a/subsystems/drivetrain.py
+++ b/subsystems/drivetrain.py
@@ -153,12 +153,9 @@ class Drivetrain(SafeSubsystem):
 
         self._field.setRobotPose(self._estimator.getEstimatedPosition())
 
-        wpilib.SmartDashboard.putNumber("Left Encoder Position", self.getLeftEncoderPosition())
-        wpilib.SmartDashboard.putNumber("Right Encoder Position", self.getRightEncoderPosition())
-        wpilib.SmartDashboard.putNumber("Left Motor", self._motor_left.get())
-        wpilib.SmartDashboard.putNumber("Right Motor", self._motor_right.get())
     def initSendable(self, builder: wpiutil.SendableBuilder) -> None:
         super().initSendable(builder)
         builder.addDoubleProperty("Left motor", self._motor_left.get, None)
         builder.addDoubleProperty("Right Motor", self._motor_right.get, None)
-
+        builder.addDoubleProperty("Left Encoder Position", self.getLeftEncoderPosition, None)
+        builder.addDoubleProperty("Right Encoder Position", self.getRightEncoderPosition, None)


### PR DESCRIPTION
Description
-----------
<!--- Fais un résumé de ce que tu as ajouté. -->
Replaced SmartDashboard.putNumber by initSendable in drivetrain
Closes #51. 

Liste de vérification
---------------------
<!-- Entre les [ ], remplace l'espace par un x lorsque c'est fait. -->
- Writing conventions :
    - [x] English language
    - [x] File names use lowercase without spaces
    - [x] Class names use PascalCase
    - [x] Functions use camelCase
    - [x] Variable names use snake_case
    - [x] Function and command names start with an action verb (get, set, move, start, stop...)
    - [x] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
    - [x] Properties respect the naming convention
- Command and subsytem safety :
    - [x] Commands and subsystems inherit from SafeCommand and SafeSubsystem
    - [x] No commands or subsytems have a `setName()` method, unless necessary
    - [x] Commands have a `addRequirements()` method that includes all the subsystems they use
- [x] J'ai exécuté tout mon code en simulation.
