### PR TITLE
58 added calibrate() function to gyro.py

### DIFF
--- a/gyro.py
+++ b/gyro.py
@@ -10,8 +10,8 @@ from wpimath.geometry import Rotation2d
 
 class Gyro(ABC):
     def __init__(self):
-        self.gyro.calibrate()
-    
+        self.calibrate()
+
     @abstractmethod
     def getAngle(self): ...
 
@@ -37,6 +37,7 @@ class Gyro(ABC):
 class NavX(Gyro):
     def __init__(self):
         self.gyro = navx.AHRS(wpilib.SerialPort.Port.kMXP)
+        super().__init__()
         gyro_sim_device = SimDeviceSim("navX-Sensor[1]")
         self._gyro_sim_angle = gyro_sim_device.getDouble("Yaw")
         self._gyro_sim_pitch = gyro_sim_device.getDouble("Pitch")
@@ -57,6 +58,7 @@ class NavX(Gyro):
 class ADIS16448(Gyro):
     def __init__(self):
         self.gyro = wpilib.ADIS16448_IMU()
+        super().__init__()
         gyro_sim_device = SimDeviceSim("Gyro:ADIS16448[4]")
         self._gyro_sim_angle = gyro_sim_device.getDouble("gyro_angle_z")
         self._gyro_sim_pitch = gyro_sim_device.getDouble("gyro_angle_y")
@@ -77,6 +79,7 @@ class ADIS16448(Gyro):
 class ADIS16470(Gyro):
     def __init__(self):
         self.gyro = wpilib.ADIS16470_IMU()
+        super().__init__()
         gyro_sim_device = SimDeviceSim("Gyro:ADIS16470[0]")
         self._gyro_sim_angle = gyro_sim_device.getDouble("gyro_angle_z")
         self._gyro_sim_pitch = gyro_sim_device.getDouble("gyro_angle_y")
@@ -97,6 +100,7 @@ class ADIS16470(Gyro):
 class ADXRS(Gyro):
     def __init__(self):
         self.gyro = wpilib.ADXRS450_Gyro()
+        super().__init__()
         gyro_sim_device = SimDeviceSim("Gyro:ADXRS450[0]")
         self._gyro_sim_angle = gyro_sim_device.getDouble("angle_x")
         self.pitch = 0
@@ -116,6 +120,7 @@ class ADXRS(Gyro):
 
 class Empty(Gyro):
     def __init__(self):
+        super().__init__()
         self._device = hal.SimDevice("Empty-Gyro")
         self._gyro_sim_angle = self._device.createDouble("yaw", hal.SimValueDirection.HAL_SimValueOutput, 0)
         self._gyro_sim_pitch = self._device.createDouble("pitch", hal.SimValueDirection.HAL_SimValueOutput, 0)

--- a/gyro.py
+++ b/gyro.py
@@ -9,6 +9,9 @@ from wpimath.geometry import Rotation2d
 
 
 class Gyro(ABC):
+    def __init__(self):
+        self.gyro.calibrate()
+    
     @abstractmethod
     def getAngle(self): ...
 
@@ -21,8 +24,11 @@ class Gyro(ABC):
     @abstractmethod
     def setSimPitch(self, angle: float): ...
 
-    @abstractmethod
-    def reset(self): ...
+    def reset(self):
+        self.gyro.reset()
+
+    def calibrate(self):
+        self.gyro.calibrate()
 
     def getRotation2d(self):
         return Rotation2d.fromDegrees(self.getAngle())
@@ -47,9 +53,6 @@ class NavX(Gyro):
     def setSimPitch(self, pitch: float):
         self._gyro_sim_pitch.set(pitch)
 
-    def reset(self):
-        self.gyro.reset()
-
 
 class ADIS16448(Gyro):
     def __init__(self):
@@ -69,9 +72,6 @@ class ADIS16448(Gyro):
 
     def setSimPitch(self, pitch: float):
         self._gyro_sim_pitch.set(pitch)
-
-    def reset(self):
-        self.gyro.reset()
 
 
 class ADIS16470(Gyro):
@@ -93,9 +93,6 @@ class ADIS16470(Gyro):
     def setSimPitch(self, pitch: float):
         self._gyro_sim_pitch.set(pitch)
 
-    def reset(self):
-        self.gyro.reset()
-
 
 class ADXRS(Gyro):
     def __init__(self):
@@ -115,9 +112,6 @@ class ADXRS(Gyro):
 
     def setSimPitch(self, pitch: float):
         self.pitch = pitch
-
-    def reset(self):
-        self.gyro.reset()
 
 
 class Empty(Gyro):
@@ -143,4 +137,7 @@ class Empty(Gyro):
         self._gyro_sim_pitch.set(pitch)
 
     def reset(self):
+        pass
+
+    def calibrate(self):
         pass

--- a/gyro.py
+++ b/gyro.py
@@ -96,6 +96,10 @@ class ADIS16470(Gyro):
     def setSimPitch(self, pitch: float):
         self._gyro_sim_pitch.set(pitch)
 
+    def calibrate(self):
+        if wpilib.RobotBase.isReal():
+            self.gyro.calibrate()
+
 
 class ADXRS(Gyro):
     def __init__(self):


### PR DESCRIPTION
Also optimised the reset function to have fewer lines

Description
-----------
<!--- Fais un résumé de ce que tu as ajouté. -->
Closes #58. 

Liste de vérification
---------------------
<!-- Entre les [ ], remplace l'espace par un x lorsque c'est fait. -->
- Writing conventions :
    - [x] English language
    - [x] File names use lowercase without spaces
    - [x] Class names use PascalCase
    - [x] Functions use camelCase
    - [x] Variable names use snake_case
    - [x] Function and command names start with an action verb (get, set, move, start, stop...)
    - [x] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
    - [x] Properties respect the naming convention
- Command and subsytem safety :
    - [x] Commands and subsystems inherit from SafeCommand and SafeSubsystem
    - [x] No commands or subsytems have a `setName()` method, unless necessary
    - [x] Commands have a `addRequirements()` method that includes all the subsystems they use
- [x] J'ai exécuté tout mon code en simulation.
