### PR TITLE
changed encoder reset method to only trigger once

### DIFF
--- a/subsystems/arm.py
+++ b/subsystems/arm.py
@@ -1,6 +1,7 @@
 import rev
 import wpiutil
 from wpilib import DigitalInput, RobotBase
+from wpilib.event import EventLoop, BooleanEvent
 from wpilib.simulation import DIOSim
 
 import ports
@@ -16,7 +17,10 @@ def checkIsInDeadzone(extension: float):
 
 class Arm(SafeSubsystem):
     extension_max_position = autoproperty(10.0)
+    extension_min_position = autoproperty(-10.0)
     elevator_max_position = autoproperty(10.0)
+    elevator_min_position = autoproperty(-10.0)
+
 
     def __init__(self):
         super().__init__()
@@ -46,6 +50,22 @@ class Arm(SafeSubsystem):
         self._extension_offset = 0.0
         self._elevator_offset = 0.0
 
+        self.loop = EventLoop()
+        self._min_elevation_event = BooleanEvent(
+            self.loop, self.isSwitchElevationMinOn
+        ).rising()
+        self._min_elevation_event.ifHigh(self.resetElevation)
+
+        self._min_extension_event = BooleanEvent(
+            self.loop, self.isSwitchExtensionMinOn
+        ).rising()
+        self._min_extension_event.ifHigh(self.resetExtension)
+
+        self._max_extension_event = BooleanEvent(
+            self.loop, self.isSwitchExtensionMaxOn
+        ).rising()
+        # self._max_extension_event.ifHigh(self.maximizeExtension)
+
         if RobotBase.isSimulation():
             self.motor_elevator_sim = SparkMaxSim(self.motor_elevator)
             self.motor_extension_sim = SparkMaxSim(self.motor_extension)
@@ -60,23 +80,19 @@ class Arm(SafeSubsystem):
         self.motor_extension_sim.setPosition(self.motor_extension_sim.getPosition() + motor_extension_sim_increment)
         self.switch_elevator_min_sim.setValue(self.getElevatorPosition() <= 0.05)
         self.switch_extension_min_sim.setValue(self.getExtensionPosition() <= 0.05)
+        self.switch_extension_max_sim.setvalue(self.getExtensionPosition() >= self.extension_max_position)
 
     def periodic(self):
-        if self.isExtensionMin():
-            self._extension_offset = self.encoder_extension.getPosition()  # Reset to zero
-        if self.isElevationMin():
-            self._elevator_offset = self.encoder_elevator.getPosition()  # Reset to zero
-        if self.isExtensionMax():
-            self._extension_offset = self.encoder_extension.getPosition() - self.extension_max_position
+        self.loop.poll()
 
-    def isExtensionMin(self):
-        return not self.switch_extension_min.get()
+    def resetExtension(self):
+        self._extension_offset = self.encoder_extension.getPosition()
 
-    def isExtensionMax(self):
-        return not self.switch_extension_max.get()
+    def resetElevation(self):
+        self._elevator_offset = self.encoder_elevator.getPosition()
 
-    def isElevationMin(self):
-        return not self.switch_elevator_min.get()
+    # def maximizeExtension(self):
+    #     self._extension_offset = self.encoder_extension.getPosition() - self.extension_max_position
 
     def getElevatorPosition(self):
         return self.encoder_elevator.getPosition() - self._elevator_offset
@@ -84,8 +100,31 @@ class Arm(SafeSubsystem):
     def getExtensionPosition(self):
         return self.encoder_extension.getPosition() - self._extension_offset
 
+    def isSwitchExtensionMinOn(self):
+        return not self.switch_extension_min.get()
+
+    def isSwitchExtensionMaxOn(self):
+        return not self.switch_extension_max.get()
+
+    def isSwitchElevationMinOn(self):
+        return not self.switch_elevator_min.get()
+
+    def isPositionExtensionMax(self):
+        return self.getExtensionPosition() > self.extension_max_position
+
+    def isPositionExtensionMin(self):
+        return self.getExtensionPosition() < self.extension_min_position
+
+    def isPositionElevationMax(self):
+        return self.getElevationPosition() > self.elevation_max_position
+
+    def isPositionElevationMax(self):
+        return self.getElevationPosition() < self.elevation_min_position
+
     def setElevatorSpeed(self, speed: float):
         if self.isElevationMin() and speed < 0:
+            speed = 0
+        if self.isElevationMax() and speed > 0:
             speed = 0
         self.motor_elevator.set(speed)
 


### PR DESCRIPTION
Description
-----------
Changed encoder resets to only trigger once
Closes #101. 

Liste de vérification
---------------------
<!-- Entre les [ ], remplace l'espace par un x lorsque c'est fait. -->
- Writing conventions :
    - [x] English language
    - [x] File names use lowercase without spaces
    - [x] Class names use PascalCase
    - [x] Functions use camelCase
    - [x] Variable names use snake_case
    - [x] Function and command names start with an action verb (get, set, move, start, stop...)
    - [x] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
    - [x] Properties respect the naming convention
- Command and subsytem safety :
    - [x] Commands and subsystems inherit from SafeCommand and SafeSubsystem
    - [x] No commands or subsytems have a `setName()` method, unless necessary
    - [x] Commands have a `addRequirements()` method that includes all the subsystems they use
- [x] J'ai exécuté tout mon code en simulation.
