### PR TITLE
111 revert utilisation des encodeur et des limitswitchs pour le bras

### DIFF
--- a/commands/drop.py
+++ b/commands/drop.py
@@ -1,17 +1,27 @@
+import commands2.cmd
+
 from subsystems.claw import Claw
 from subsystems.arm import Arm
 
 from commands.openclaw import OpenClaw
-from commands.movearm import MoveArm
+from commands.movearm import MoveArm, properties
 
-from commands2 import SequentialCommandGroup
+from commands2 import SequentialCommandGroup, ConditionalCommand
 
+from utils.property import autoproperty
 from utils.safecommand import SafeMixin
 
 
 class Drop(SafeMixin, SequentialCommandGroup):
+    level3_arm_threshold = autoproperty(5.0)
+
     def __init__(self, claw: Claw, arm: Arm):
         super().__init__(
+            ConditionalCommand(
+                MoveArm.toLevel3Drop(arm),
+                commands2.cmd.nothing(),
+                lambda: abs(arm.getExtensionPosition() - properties.level3_extension) <= self.level3_arm_threshold
+            ),
             OpenClaw(claw),
             MoveArm.toBase(arm)
         )

--- a/commands/movearm.py
+++ b/commands/movearm.py
@@ -27,6 +27,12 @@ class MoveArm(SafeMixin, ConditionalCommand):
         return cmd
 
     @classmethod
+    def toLevel3Drop(cls, arm: Arm):
+        cmd = cls(arm, lambda: properties.level3_drop_extension, lambda: properties.level3_drop_elevation)
+        cmd.setName(cmd.getName() + ".toLevel3_drop")
+        return cmd
+
+    @classmethod
     def toFloor(cls, arm: Arm):
         cmd = cls(arm, lambda: properties.floor_extension, lambda: properties.floor_elevation)
         cmd.setName(cmd.getName() + ".toFloor")
@@ -238,6 +244,7 @@ class _ClassProperties:
     level1_extension = autoproperty(0.0, subtable=MoveArm.__name__)
     level2_extension = autoproperty(0.0, subtable=MoveArm.__name__)
     level3_extension = autoproperty(0.0, subtable=MoveArm.__name__)
+    level3_drop_extension = autoproperty(0.0, subtable=MoveArm.__name__)
     floor_extension = autoproperty(0.0, subtable=MoveArm.__name__)
     base_extension = autoproperty(0.0, subtable=MoveArm.__name__)
     bin_extension = autoproperty(0.0, subtable=MoveArm.__name__)
@@ -251,6 +258,7 @@ class _ClassProperties:
     level1_elevation = autoproperty(0.0, subtable=MoveArm.__name__)
     level2_elevation = autoproperty(0.0, subtable=MoveArm.__name__)
     level3_elevation = autoproperty(0.0, subtable=MoveArm.__name__)
+    level3_drop_elevation = autoproperty(0.0, subtable=MoveArm.__name__)
     floor_elevation = autoproperty(0.0, subtable=MoveArm.__name__)
     base_elevation = autoproperty(0.0, subtable=MoveArm.__name__)
     bin_elevation = autoproperty(0.0, subtable=MoveArm.__name__)

--- a/commands/resetarm.py
+++ b/commands/resetarm.py
@@ -11,40 +11,20 @@ class ResetArm(SafeCommand):
         super().__init__()
         self.arm = arm
         self.addRequirements(self.arm)
-        self._has_reset_extension = False
-        self._has_reset_elevator = False
-
-    def initialize(self) -> None:
-        self._has_reset_extension = False
-        self._has_reset_elevator = False
-        self.arm._elevator_offset = float("-inf")
-        self.arm._extension_offset = float("-inf")
 
     def execute(self) -> None:
-        if not self._has_reset_elevator:
-            if self.arm._elevator_offset > float("-inf"):
-                self._has_reset_elevator = True
-                self.arm.motor_elevator.set(0.0)
-            elif self.arm.isSwitchElevatorMinOn():
-                self.arm.motor_elevator.set(self.elevator_speed)
-            else:
-                self.arm.motor_elevator.set(-self.elevator_speed)
+        if not self.arm.isSwitchElevatorMinOn():
+            self.arm.setElevatorSpeed(-self.elevator_speed)
         else:
-            self.arm.motor_elevator.set(0.0)
+            self.arm.setElevatorSpeed(0.0)
 
-        if not self._has_reset_extension:
-            if self.arm._extension_offset > float("-inf"):
-                self._has_reset_extension = True
-                self.arm.motor_extension.set(0.0)
-            elif self.arm.isSwitchExtensionMinOn():
-                self.arm.motor_extension.set(self.extension_speed)
-            else:
-                self.arm.motor_extension.set(-self.extension_speed)
+        if not self.arm.isSwitchExtensionMinOn():
+            self.arm.setExtensionSpeed(-self.extension_speed)
         else:
-            self.arm.motor_extension.set(0.0)
+            self.arm.setExtensionSpeed(0.0)
 
     def isFinished(self) -> bool:
-        return self._has_reset_extension and self._has_reset_elevator
+        return self.arm.isSwitchElevatorMinOn() and self.arm.isSwitchExtensionMinOn()
 
     def end(self, interrupted: bool) -> None:
         self.arm.setElevatorSpeed(0.0)

--- a/subsystems/arm.py
+++ b/subsystems/arm.py
@@ -17,10 +17,7 @@ def checkIsInDeadzone(extension: float):
 
 
 class Arm(SafeSubsystem):
-    extension_max_position = autoproperty(10.0)
-    extension_min_position = autoproperty(-10.0)
     elevator_max_position = autoproperty(10.0)
-    elevator_min_position = autoproperty(-10.0)
 
     def __init__(self):
         super().__init__()
@@ -56,18 +53,18 @@ class Arm(SafeSubsystem):
         self.loop = EventLoop()
         self._min_elevator_event = BooleanEvent(
             self.loop, self.isSwitchElevatorMinOn
-        ).rising()
+        )
         self._min_elevator_event.ifHigh(self.resetElevator)
 
         self._min_extension_event = BooleanEvent(
             self.loop, self.isSwitchExtensionMinOn
-        ).rising()
+        )
         self._min_extension_event.ifHigh(self.resetExtension)
 
         self._max_extension_event = BooleanEvent(
             self.loop, self.isSwitchExtensionMaxOn
-        ).rising()
-        # self._max_extension_event.ifHigh(self.maximizeExtension)
+        )
+        self._max_extension_event.ifHigh(self.maximizeExtension)
 
         if RobotBase.isSimulation():
             self.motor_elevator_sim = SparkMaxSim(self.motor_elevator)
@@ -117,16 +114,16 @@ class Arm(SafeSubsystem):
         return not self.switch_elevator_min.get()
 
     def isExtensionMax(self):
-        return self.getExtensionPosition() > self.extension_max_position
+        return self.isSwitchExtensionMaxOn()
 
     def isExtensionMin(self):
-        return self.getExtensionPosition() < self.extension_min_position
+        return self.isSwitchExtensionMinOn()
 
     def isElevatorMax(self):
         return self.getElevatorPosition() > self.elevator_max_position
 
     def isElevatorMin(self):
-        return self.getElevatorPosition() < self.elevator_min_position
+        return self.isSwitchElevatorMinOn()
 
     def setElevatorSpeed(self, speed: float):
         if self.isElevatorMin() and speed < 0:

--- a/subsystems/arm.py
+++ b/subsystems/arm.py
@@ -61,10 +61,10 @@ class Arm(SafeSubsystem):
         )
         self._min_extension_event.ifHigh(self.resetExtension)
 
-        self._max_extension_event = BooleanEvent(
-            self.loop, self.isSwitchExtensionMaxOn
-        )
-        self._max_extension_event.ifHigh(self.maximizeExtension)
+        # self._max_extension_event = BooleanEvent(
+        #     self.loop, self.isSwitchExtensionMaxOn
+        # ).rising()
+        # self._max_extension_event.ifHigh(self.maximizeExtension)
 
         if RobotBase.isSimulation():
             self.motor_elevator_sim = SparkMaxSim(self.motor_elevator)


### PR DESCRIPTION
Description
-----------
<!--- Fais un résumé de ce que tu as ajouté. -->
Closes #111. 

Liste de vérification
---------------------
<!-- Entre les [ ], remplace l'espace par un x lorsque c'est fait. -->
- Writing conventions :
    - [ ] English language
    - [ ] File names use lowercase without spaces
    - [ ] Class names use PascalCase
    - [ ] Functions use camelCase
    - [ ] Variable names use snake_case
    - [ ] Function and command names start with an action verb (get, set, move, start, stop...)
    - [ ] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
    - [ ] Properties respect the naming convention
- Command and subsytem safety :
    - [ ] Commands and subsystems inherit from SafeCommand and SafeSubsystem
    - [ ] No commands or subsytems have a `setName()` method, unless necessary
    - [ ] Commands have a `addRequirements()` method that includes all the subsystems they use
- [ ] J'ai exécuté tout mon code en simulation.
